### PR TITLE
gitignore: correct coverage.text, ignore vim swap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ ocibuilder.iml
 dist/
 vendor/
 */.DS_Store
+*.swp
 
 # Binaries for programs and plugins
 *.exe
@@ -18,4 +19,4 @@ vendor/
 *.out
 
 # ignore coverage.text
-coverage/
+coverage.text


### PR DESCRIPTION
This fixes `.gitignore` to properly ignore `coverage.text`, and tosses in `*.swp` for vim users.