### PR TITLE
feat(): image inspect to clients

### DIFF
--- a/pkg/apis/ocibuilder/v1alpha1/interfaces.go
+++ b/pkg/apis/ocibuilder/v1alpha1/interfaces.go
@@ -28,6 +28,7 @@ type BuilderClient interface {
 	ImagePull(options OCIPullOptions) (OCIPullResponse, error)
 	ImagePush(options OCIPushOptions) (OCIPushResponse, error)
 	ImageRemove(options OCIRemoveOptions) (OCIRemoveResponse, error)
+	ImageInspect(imageId string) (types.ImageInspect, error)
 	RegistryLogin(options OCILoginOptions) (OCILoginResponse, error)
 	GenerateAuthRegistryString(auth types.AuthConfig) string
 }

--- a/pkg/buildah/client.go
+++ b/pkg/buildah/client.go
@@ -17,8 +17,10 @@ limitations under the License.
 package buildah
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
@@ -129,9 +131,33 @@ func (cli Client) ImageRemove(options v1alpha1.OCIRemoveOptions) (v1alpha1.OCIRe
 	}, nil
 }
 
-// ImageRemove conducts an inspect of a build image with Buildah using the ocibuilder
+// @TBC
+// ImageInspect conducts an inspect of a build image with Buildah using the ocibuilder
+//
+// The type currently returned by running buildah inspect varies greatly to docker image inspect
+// issues have been created to manage this and have a more representative mapping between buildah and docker
 func (cli Client) ImageInspect(imageId string) (types.ImageInspect, error) {
 
+	inspectFlag := command.Flag{
+		Name: "type", Value: "image", Short: false, OmitEmpty: false,
+	}
+
+	cmd := command.Builder("buildah").Command("inspect").Flags(inspectFlag).Args(imageId).Build()
+	cli.Logger.WithField("cmd", cmd).Debugln("executing remove with command")
+
+	stdout, _, err := execute(&cmd)
+	if err != nil {
+		cli.Logger.WithError(err).Errorln("error building image...")
+		return types.ImageInspect{}, err
+	}
+	var imageInspect types.ImageInspect
+	res, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		return types.ImageInspect{}, err
+	}
+	if err := json.Unmarshal(res, imageInspect); err != nil {
+		return types.ImageInspect{}, err
+	}
 	return types.ImageInspect{}, nil
 }
 

--- a/pkg/buildah/client.go
+++ b/pkg/buildah/client.go
@@ -129,6 +129,12 @@ func (cli Client) ImageRemove(options v1alpha1.OCIRemoveOptions) (v1alpha1.OCIRe
 	}, nil
 }
 
+// ImageRemove conducts an inspect of a build image with Buildah using the ocibuilder
+func (cli Client) ImageInspect(imageId string) (types.ImageInspect, error) {
+
+	return types.ImageInspect{}, nil
+}
+
 // RegistryLogin conducts a registry login with Buildah using the ocibuilder
 func (cli Client) RegistryLogin(options v1alpha1.OCILoginOptions) (v1alpha1.OCILoginResponse, error) {
 

--- a/pkg/buildah/client.go
+++ b/pkg/buildah/client.go
@@ -155,7 +155,7 @@ func (cli Client) ImageInspect(imageId string) (types.ImageInspect, error) {
 	if err != nil {
 		return types.ImageInspect{}, err
 	}
-	if err := json.Unmarshal(res, imageInspect); err != nil {
+	if err := json.Unmarshal(res, &imageInspect); err != nil {
 		return types.ImageInspect{}, err
 	}
 	return types.ImageInspect{}, nil

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 
@@ -79,6 +80,16 @@ func (cli Client) ImageRemove(options v1alpha1.OCIRemoveOptions) (v1alpha1.OCIRe
 	return v1alpha1.OCIRemoveResponse{
 		Response: res,
 	}, nil
+}
+
+// ImageInspect conducts an inspect of a built image with Docker using the ocibuilder
+func (cli Client) ImageInspect(imageId string) (types.ImageInspect, error) {
+	apiCli := cli.APIClient
+	res, _, err := apiCli.ImageInspectWithRaw(context.Background(), imageId)
+	if err != nil {
+		return types.ImageInspect{}, err
+	}
+	return res, nil
 }
 
 // RegistryLogin conducts a registry login with Docker using the ocibuilder

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -103,6 +103,9 @@ func (t testClient) ImagePush(options v1alpha1.OCIPushOptions) (v1alpha1.OCIPush
 func (t testClient) ImageRemove(options v1alpha1.OCIRemoveOptions) (v1alpha1.OCIRemoveResponse, error) {
 	return v1alpha1.OCIRemoveResponse{}, nil
 }
+func (t testClient) ImageInspect(imageId string) (types.ImageInspect, error) {
+	return types.ImageInspect{}, nil
+}
 func (t testClient) RegistryLogin(options v1alpha1.OCILoginOptions) (v1alpha1.OCILoginResponse, error) {
 	return v1alpha1.OCILoginResponse{}, nil
 }


### PR DESCRIPTION
Adding support for image inspect to the docker and buildah clients to enable the discovery of image metadata for grafeas integration.

Buildah integration is TBC - see #119 